### PR TITLE
Update prepare_commands.sh

### DIFF
--- a/prepare_commands.sh
+++ b/prepare_commands.sh
@@ -3,5 +3,5 @@ for pdb in $(cat pdb_list.txt);
 do
   p2=$(echo $pdb | cut -c -2);
   mkdir -p out/$p2;
-  echo "curl --silent "http://www.rcsb.org/pdb/files/$pdb.sifts.xml" | python2 parse_sifts.py 1> out/$p2/$pdb.tsv 2> /dev/null";
+  echo "curl --silent "ftp://ftp.ebi.ac.uk/pub/databases/msd/sifts/xml/$pdb.xml.gz" | gunzip | python2 parse_sifts.py 1> out/$p2/$pdb.tsv 2> /dev/null";
 done


### PR DESCRIPTION
Links to XML files no longer work. Updated to use new links from ftp. 
See https://www.ebi.ac.uk/pdbe/docs/sifts/quick.html

Works ok now!